### PR TITLE
Add functionality to connect form to GitHub repo

### DIFF
--- a/client/src/app/components/LoadScreen.js
+++ b/client/src/app/components/LoadScreen.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const LoadScreen = () => (
+    <div>
+        <div className='spinner-container'>
+            <i className='loading-spinner'></i>
+        </div>
+        <span>{this.props.authFetching && 'Authorizing on Github'}</span>
+    </div>
+)
+
+export default LoadScreen

--- a/client/src/app/components/LoadScreen.js
+++ b/client/src/app/components/LoadScreen.js
@@ -5,7 +5,7 @@ const LoadScreen = () => (
         <div className='spinner-container'>
             <i className='loading-spinner'></i>
         </div>
-        <span>{this.props.authFetching && 'Authorizing on Github'}</span>
+        <span>Authorizing on Github</span>
     </div>
 )
 

--- a/client/src/app/components/LoadScreen.js
+++ b/client/src/app/components/LoadScreen.js
@@ -1,9 +1,9 @@
 import React from 'react'
 
 const LoadScreen = () => (
-    <div>
-        <div className='spinner-container'>
-            <i className='loading-spinner'></i>
+    <div className="load-screen__container">
+        <div className='load-screen__spinner-container'>
+            <i className='load-screen__spinner'></i>
         </div>
         <span>Authorizing on Github</span>
     </div>

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -2,13 +2,11 @@ import React, { Component, Fragment } from 'react'
 import { connect } from "react-redux";
 
 import LoginForm from './LoginForm'
+import RepoForm from './RepoForm'
 
 let mapStateToProps = state => ({
     ghStateToken: state.authenticate.ghStateToken,
-    authenticateError: state.authenticate.error,
-    authenticateFetching: state.authenticate.isFetching,
-    authorizeError: state.authorize.error,
-    authorizeFetching: state.authorize.isFetching,
+    authenticated: state.authenticate.authenticated,
     authorized: state.authorize.authorized
 })
 
@@ -24,6 +22,12 @@ class Login extends Component {
     }
 
     handleTextInput(ev) { this.setState({ targetRepo: ev.target.value }) }
+
+    handleSubmit(ev, repo) {
+        ev.preventDefault()
+        sessionStorage.setItem('target_repo', repo)
+        this.props.authorize.setRepo(repo)
+    }
 
     render() {
         let errorMessage = this.props.authError && (
@@ -58,26 +62,26 @@ class Login extends Component {
             </div>
         )
 
+        let qs = `client_id=8390933a81635970d3b6&state=${this.props.ghStateToken}&scope=public_repo%20read:user`
+
         return (
             <Fragment>
-                { errorMessage }
+                { errorMessage /* TODO: These should both be global */ }
                 { unauthorized }
                 <div style={{ display: 'flex', paddingTop: '6rem', width: '100vw', flexFlow: 'row', justifyContent: 'center', alignItems: 'center' }}>
                     <div style={{ marginBottom: '8rem' }}>
                         {
-                            this.props.authFetching
+                            this.props.authenticated
                             ? (
-                                <div>
-                                    <div className='spinner-container'>
-                                        <i className='loading-spinner'></i>
-                                    </div>
-                                    <span>{ this.props.authFetching && 'Authorizing on Github' }</span>
-                                </div>
+                                <RepoForm
+                                    targetRepo={ this.state.targetRepo }
+                                    handleTextInput={ ev => this.handleTextInput(ev) }
+                                    handleSubmit={ ev => this.handleSubmit(ev, this.state.targetRepo) }
+                                />
                             ) : <LoginForm
-                                unauthorized={ Boolean(unauthorized) }
-                                targetRepo={ this.state.targetRepo } 
+                                targetRepo={ this.state.targetRepo }
                                 handleTextInput={ ev => this.handleTextInput(ev) }
-                                qs={ `client_id=8390933a81635970d3b6&state=${this.props.ghStateToken}&scope=public_repo%20read:user` }
+                                qs={ qs }
                               />
                         }
                     </div>

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -6,24 +6,25 @@ import { setStateToken, setAuthToken, exchangeStateAndCodeForToken } from '../st
 import Gh from '../utils/GithubClient'
 
 let mapStateToProps = state => ({
-    ghAuthToken: state.auth.ghAuthToken,
-    fetchingToken: state.auth.isFetching,
+    ghStateToken: state.auth.ghStateToken,
     authError: state.auth.error
 })
 
-let mapDispatchToProps = dispatch => ({
-    setAuthToken: token => dispatch(setAuthToken(token)),
-    exchangeStateAndCodeForToken: (stateToken, code) => dispatch(exchangeStateAndCodeForToken(stateToken, code)),
-    setStateToken: stateToken => dispatch(setStateToken(stateToken))
-})
-
 @connect(
-    mapStateToProps,
-    mapDispatchToProps
+    mapStateToProps
 )
 class Login extends Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            targetRepo: ''
+        }
+    }
+
+    handleTextInput(ev) { this.setState({ targetRepo: ev.target.value }) }
+
     render() {
-        let qs = `client_id=8390933a81635970d3b6&state=${this.state.ghStateToken}&scope=public_repo%20read:user`
+        let qs = `client_id=8390933a81635970d3b6&state=${this.props.ghStateToken}&scope=public_repo%20read:user`
         let errorMessage = this.props.authError && (
             <div style={{
                 backgroundColor: '#e80801',
@@ -41,11 +42,23 @@ class Login extends Component {
         return (
             <Fragment>
                 { errorMessage }
-                <div>
-                    <a
-                        href={ `https://github.com/login/oauth/authorize?${qs}` }
-                        className="editor_button editor_button--primary"
-                    >Login to GitHub</a>
+                <div style={{ display: 'flex', width: '100vw', flexFlow: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                    <div style={{ marginBottom: '2rem' }}>
+                        <label htmlFor="target-repo">Enter the full URL of the GitHub repo you want to add a publiccode.yml file to</label>
+                        <aside>Enter the complete URL of the repo, starting with &ldquo;https://&rdquo;</aside>
+                        <input
+                            id="target-repo"
+                            type="text"
+                            placeholder="https://github.com/repo-owner/repo-name"
+                            value={ this.state.targetRepo }
+                            onChange={ ev => this.handleTextInput(ev) }
+                        />
+                        <a
+                            href={ `https://github.com/login/oauth/authorize?${qs}` }
+                            onClick={ () => sessionStorage.setItem('TARGET_REPO', this.state.targetRepo) }
+                            className="editor_button editor_button--primary"
+                        >Login to GitHub</a>
+                    </div>
                 </div>
             </Fragment>
         )

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -40,8 +40,10 @@ class Login extends Component {
             </div>
         )
 
+        let targetRepo = window.sessionStorage.getItem('target_repo')
         let unauthorized = this.props.authorized === 'unauthorized' && (
             <div style={{
+                border: '1px solid #5a768a',
                 backgroundColor: '#e8e8e8',
                 width: '100%',
                 position: 'absolute',
@@ -52,7 +54,7 @@ class Login extends Component {
                 textAlign: 'center'
             }}>
                 <h3>Looks like you don&apos;t have sufficient permissions on the GitHub repository</h3>
-                <p>Talk to a project admin to get your permissions elevated</p>
+                <p>Talk to a project collaborator to get your permissions changed for the repo {targetRepo}</p>
             </div>
         )
 
@@ -60,8 +62,8 @@ class Login extends Component {
             <Fragment>
                 { errorMessage }
                 { unauthorized }
-                <div style={{ display: 'flex', width: '100vw', flexFlow: 'row', justifyContent: 'center', alignItems: 'center' }}>
-                    <div style={{ marginBottom: '4rem', paddingTop: '2rem' }}>
+                <div style={{ display: 'flex', paddingTop: '6rem', width: '100vw', flexFlow: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                    <div style={{ marginBottom: '8rem' }}>
                         {
                             this.props.authFetching
                             ? (
@@ -72,6 +74,7 @@ class Login extends Component {
                                     <span>{ this.props.authFetching && 'Authorizing on Github' }</span>
                                 </div>
                             ) : <LoginForm
+                                unauthorized={ Boolean(unauthorized) }
                                 targetRepo={ this.state.targetRepo } 
                                 handleTextInput={ ev => this.handleTextInput(ev) }
                                 qs={ `client_id=8390933a81635970d3b6&state=${this.props.ghStateToken}&scope=public_repo%20read:user` }

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -17,75 +17,11 @@ let mapDispatchToProps = dispatch => ({
     setStateToken: stateToken => dispatch(setStateToken(stateToken))
 })
 
-// @connect(
-//     mapStateToProps,
-//     mapDispatchToProps
-// )
+@connect(
+    mapStateToProps,
+    mapDispatchToProps
+)
 class Login extends Component {
-    constructor() {
-        super()
-        this.state = {
-            ghStateToken: null
-        }
-    }
-
-    getCodeAndStateFromQs(qs) {
-        qs = qs.slice(1)
-        if (!qs) return false
-        let params = qs.split('&')
-
-        let code = params.find(param => param.startsWith('code='))
-        code = code && decodeURI(code.split('=')[1])
-
-        let stateToken = params.find(param => param.startsWith('state='))
-        stateToken = stateToken && decodeURI(stateToken.split('=')[1])
-
-        return { code, stateToken }
-    }
-
-    storeTokenLocally(key, token) {
-        if (token) {
-            localStorage.setItem(key, token)
-        }
-    }
-
-    /**
-     * When component mounts,
-     *   1. check for GH auth token on localStorage
-     *      - if present, user is authorized
-     *   2. if no GH auth token, check for [ GH state token, code ] in `qs` & [ GH state token ] in `localStorage`
-     *      - if found, user is mid-auth-flow, exchange GH code for auth token
-     *   3. if no [ GH state token | code ] on `qs` or no [ GH state token ] in `localStorage`, user has yet to authorize
-     *      - generate Gh state token, hold it in state & save it in localStorage
-     */
-    componentDidMount() {
-        // if ghAuthToken is on localStorage and not Redux, this must be first load
-        let storedToken = window.localStorage.getItem('GH_AUTH_TOKEN')
-        if (storedToken || this.props.ghAuthToken !== null) {
-            if (storedToken && this.props.ghAuthToken === null) {
-                this.props.setAuthToken(window.localStorage.getItem('GH_AUTH_TOKEN'))
-            }
-            // if ghAuthToken is on Redux but not on localStorage, we gotta store it on localStorage
-            else if (!storedToken && this.props.ghAuthToken !== null) {
-                this.storeTokenLocally('GH_AUTH_TOKEN', this.props.ghAuthToken)
-            }
-            return
-        }
-
-        // if no ghAuthToken found anywhere, check for gh state token & code
-        let { code, stateToken } = this.getCodeAndStateFromQs(window.location.search)
-        let storedStateToken = window.localStorage.getItem('GH_STATE_TOKEN')
-        // if we have code & state tokens match in qs & localStorage
-        // use them to fetch ghAuthToken
-        if (code && stateToken && storedStateToken && stateToken === storedStateToken) {
-            this.props.exchangeStateAndCodeForToken(stateToken, code)
-        } else {
-            const ghStateToken = Gh.generateState()
-            localStorage.setItem('GH_STATE_TOKEN', ghStateToken)
-            this.setState({ ghStateToken })
-        }
-    }
-
     render() {
         let qs = `client_id=8390933a81635970d3b6&state=${this.state.ghStateToken}&scope=public_repo%20read:user`
         let errorMessage = this.props.authError && (
@@ -116,4 +52,4 @@ class Login extends Component {
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Login)
+export default Login

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -43,7 +43,7 @@ class Login extends Component {
             <Fragment>
                 { errorMessage }
                 <div style={{ display: 'flex', width: '100vw', flexFlow: 'row', justifyContent: 'center', alignItems: 'center' }}>
-                    <div style={{ marginBottom: '2rem' }}>
+                    <div style={{ marginBottom: '4rem', paddingTop: '2rem' }}>
                         <label htmlFor="target-repo">Enter the full URL of the GitHub repo you want to add a publiccode.yml file to</label>
                         <aside>Enter the complete URL of the repo, starting with &ldquo;https://&rdquo;</aside>
                         <input
@@ -55,7 +55,7 @@ class Login extends Component {
                         />
                         <a
                             href={ `https://github.com/login/oauth/authorize?${qs}` }
-                            onClick={ () => sessionStorage.setItem('TARGET_REPO', this.state.targetRepo) }
+                            onClick={ () => sessionStorage.setItem('target_repo', this.state.targetRepo) }
                             className="editor_button editor_button--primary"
                         >Login to GitHub</a>
                     </div>

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -4,10 +4,12 @@ import { connect } from "react-redux";
 import LoginForm from './LoginForm'
 
 let mapStateToProps = state => ({
-    ghStateToken: state.auth.ghStateToken,
-    authError: state.auth.error,
-    authFetching: state.auth.isFetching,
-    authorized: state.auth.authorized
+    ghStateToken: state.authenticate.ghStateToken,
+    authenticateError: state.authenticate.error,
+    authenticateFetching: state.authenticate.isFetching,
+    authorizeError: state.authorize.error,
+    authorizeFetching: state.authorize.isFetching,
+    authorized: state.authorize.authorized
 })
 
 @connect(

--- a/client/src/app/components/Login.js
+++ b/client/src/app/components/Login.js
@@ -3,15 +3,22 @@ import { connect } from "react-redux";
 
 import LoginForm from './LoginForm'
 import RepoForm from './RepoForm'
+import { fetchUserPermission } from '../store/authorize';
 
 let mapStateToProps = state => ({
+    ghAuthToken: state.authenticate.ghAuthToken,
     ghStateToken: state.authenticate.ghStateToken,
     authenticated: state.authenticate.authenticated,
     authorized: state.authorize.authorized
 })
 
+let mapDispatchToProps = dispatch => ({
+    fetchUserPermission: (token, owner, repo) => dispatch(fetchUserPermission(token, owner, repo))
+})
+
 @connect(
-    mapStateToProps
+    mapStateToProps,
+    mapDispatchToProps
 )
 class Login extends Component {
     constructor(props) {
@@ -26,7 +33,7 @@ class Login extends Component {
     handleSubmit(ev, repo) {
         ev.preventDefault()
         sessionStorage.setItem('target_repo', repo)
-        this.props.authorize.setRepo(repo)
+        this.props.fetchUserPermission(this.props.ghAuthToken, repo)
     }
 
     render() {

--- a/client/src/app/components/LoginForm.js
+++ b/client/src/app/components/LoginForm.js
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react'
 const LoginForm = props => {
     return (
         <Fragment>
+            { props.unauthorized && <h3>Try another repository?</h3> }
             <label htmlFor="target-repo">Enter the full URL of the GitHub repo you want to add a publiccode.yml file to</label>
             <aside>Enter the complete URL of the repo, starting with &ldquo;https://&rdquo;</aside>
             <input
@@ -16,7 +17,7 @@ const LoginForm = props => {
                 href={ `https://github.com/login/oauth/authorize?${ props.qs }` }
                 onClick={ () => sessionStorage.setItem('target_repo', props.targetRepo) }
                 className="editor_button editor_button--primary"
-            >Login to GitHub</a>
+            >{ props.unauthorized ? 'Connect repo' : 'Login to GitHub' }</a>
         </Fragment>
     )
 }

--- a/client/src/app/components/LoginForm.js
+++ b/client/src/app/components/LoginForm.js
@@ -1,0 +1,24 @@
+import React, { Fragment } from 'react'
+
+const LoginForm = props => {
+    return (
+        <Fragment>
+            <label htmlFor="target-repo">Enter the full URL of the GitHub repo you want to add a publiccode.yml file to</label>
+            <aside>Enter the complete URL of the repo, starting with &ldquo;https://&rdquo;</aside>
+            <input
+                id="target-repo"
+                type="text"
+                placeholder="https://github.com/repo-owner/repo-name"
+                value={ props.targetRepo }
+                onChange={ ev => props.handleTextInput(ev) }
+            />
+            <a
+                href={ `https://github.com/login/oauth/authorize?${ props.qs }` }
+                onClick={ () => sessionStorage.setItem('target_repo', props.targetRepo) }
+                className="editor_button editor_button--primary"
+            >Login to GitHub</a>
+        </Fragment>
+    )
+}
+
+export default LoginForm

--- a/client/src/app/components/RepoForm.js
+++ b/client/src/app/components/RepoForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const RepoForm = props => (
-    <form>
+    <form onSubmit={ ev => props.handleSubmit(ev) }>
         {/* TODO: Check 'unauthorized' here */}
         <label htmlFor="target-repo">Enter the full URL of the GitHub repo you want to add a publiccode.yml file to</label>
         <aside>Enter the complete URL of the repo, starting with &ldquo;https://&rdquo;</aside>
@@ -14,7 +14,6 @@ const RepoForm = props => (
         />
         <button
             type="submit"
-            onSubmit={ ev => props.handleSubmit(ev) }
             className="editor_button editor_button--primary"
         >Connect Repo</button>
     </form>

--- a/client/src/app/components/RepoForm.js
+++ b/client/src/app/components/RepoForm.js
@@ -1,7 +1,8 @@
 import React from 'react'
 
-const LoginForm = props => (
+const RepoForm = props => (
     <form>
+        {/* TODO: Check 'unauthorized' here */}
         <label htmlFor="target-repo">Enter the full URL of the GitHub repo you want to add a publiccode.yml file to</label>
         <aside>Enter the complete URL of the repo, starting with &ldquo;https://&rdquo;</aside>
         <input
@@ -11,12 +12,12 @@ const LoginForm = props => (
             value={ props.targetRepo }
             onChange={ ev => props.handleTextInput(ev) }
         />
-        <a
-            href={ `https://github.com/login/oauth/authorize?${ props.qs }` }
-            onClick={ () => sessionStorage.setItem('target_repo', props.targetRepo) }
+        <button
+            type="submit"
+            onSubmit={ ev => props.handleSubmit(ev) }
             className="editor_button editor_button--primary"
-        >Login to GitHub</a>
+        >Connect Repo</button>
     </form>
 )
 
-export default LoginForm
+export default RepoForm

--- a/client/src/app/components/editor.js
+++ b/client/src/app/components/editor.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { initialize, submit } from "redux-form";
 import { notify } from "../store/notifications";
 import { setVersions } from "../store/cache";
+import { unsetAndUnstoreRepo } from '../store/authorize';
 import { APP_FORM } from "../contents/constants";
 import { getData, SUMMARY } from "../contents/data";
 import jsyaml from "../../../node_modules/js-yaml/dist/js-yaml.js";
@@ -28,7 +29,8 @@ const mapStateToProps = state => {
     notifications: state.notifications,
     cache: state.cache,
     form: state.form,
-    yamlLoaded: state.yamlLoaded
+    yamlLoaded: state.yamlLoaded,
+    targetRepo: state.authorize.repo
   };
 };
 
@@ -38,6 +40,7 @@ const mapDispatchToProps = dispatch => {
     submit: name => dispatch(submit(name)),
     notify: data => dispatch(notify(data)),
     setVersions: data => dispatch(setVersions(data)),
+    unsetRepo: () => dispatch(unsetAndUnstoreRepo())
   };
 };
 
@@ -356,6 +359,11 @@ class Editor extends Component {
     this.setState({ activeSection: activeSection });
   }
 
+  unsetTargetRepo(ev) {
+    ev.preventDefault()
+    this.props.unsetRepo()
+  }
+
   render() {
     let {
       currentLanguage,
@@ -379,7 +387,11 @@ class Editor extends Component {
     return (
       <Fragment>
         <div className="content">
-          <Head lastGen={lastGen} />
+          <Head
+            lastGen={lastGen}
+            targetRepo={ this.props.targetRepo }
+            handleClick={ ev => this.unsetTargetRepo(ev) }
+          />
           {this.langSwitcher()}
           <div className="content__main" id="content__main">
             {currentLanguage &&

--- a/client/src/app/components/head.js
+++ b/client/src/app/components/head.js
@@ -48,24 +48,30 @@ class head extends Component {
   render() {
     let { info } = this.state;
     return (
-      <div className="content__head">
-        <div className="content__head__title">publiccode.yml Pusher</div>
-        <div className="content__head__help">
-          <div>
-            <a className="pr-5" href={privacyPolicyUrl} rel="noopener noreferrer" target="_blank">
-              Privacy policy
-            </a>
-            <a href={repositoryUrl} rel="noopener noreferrer" target="_blank">
-              Need help?
-            </a>
+      <div>
+        <div className="content__head">
+          <div className="content__head__title">publiccode.yml Pusher</div>
+          <div className="content__head__help">
+            <div>
+              <a className="pr-5" href={privacyPolicyUrl} rel="noopener noreferrer" target="_blank">
+                Privacy policy
+              </a>
+              <a href={repositoryUrl} rel="noopener noreferrer" target="_blank">
+                Need help?
+              </a>
+            </div>
+            <div>
+              {info && (
+                <span className="content__head__status">
+                  Last generation: {info}
+                </span>
+              )}
+            </div>
           </div>
-          <div>
-            {info && (
-              <span className="content__head__status">
-                Last generation: {info}
-              </span>
-            )}
-          </div>
+        </div>
+        <div className="content__target-repo">
+          <h2>Connected to { this.props.targetRepo }</h2>
+          <button onClick={ ev => this.props.handleClick(ev) }>Connect to a different repo</button>
         </div>
       </div>
     );

--- a/client/src/app/components/head.js
+++ b/client/src/app/components/head.js
@@ -49,7 +49,7 @@ class head extends Component {
     let { info } = this.state;
     return (
       <div className="content__head">
-        <div className="content__head__title">publiccode.yml Editor</div>
+        <div className="content__head__title">publiccode.yml Pusher</div>
         <div className="content__head__help">
           <div>
             <a className="pr-5" href={privacyPolicyUrl} rel="noopener noreferrer" target="_blank">

--- a/client/src/app/components/index.js
+++ b/client/src/app/components/index.js
@@ -146,7 +146,7 @@ class Index extends Component {
 
     render() {
         return (
-            this.props.authenticated
+            this.props.authorized === 'authorized'
             ? <Editor/>
             : <Login/>
         )

--- a/client/src/app/components/index.js
+++ b/client/src/app/components/index.js
@@ -41,7 +41,6 @@ class Index extends Component {
 
     checkAuthState() {
         let storedToken = window.sessionStorage.getItem('GH_AUTH_TOKEN')
-        console.log(`retrieved stored token ${storedToken}`)
 
         // if auth token found, 'authenticated'
         if (this.props.authenticated === true && storedToken) {
@@ -102,7 +101,6 @@ class Index extends Component {
     fetchPermissionForStoredRepo(token) {
         let target = window.sessionStorage.getItem('target_repo') // grab repo url that was stored before redirect to GitHub auth page
         let [ owner, repo ] = target.replace(/https*:\/\/github.com\//, '').split('/')
-        console.log(`got owner, ${owner}, and repo name, ${repo} for target repo ${target}`)
         this.props.fetchUserPermission(token, owner, repo)
     }
 

--- a/client/src/app/components/index.js
+++ b/client/src/app/components/index.js
@@ -1,17 +1,103 @@
 import React, { Component } from "react"
 import { connect } from "react-redux";
 
+import { setStateToken, setAuthToken, exchangeStateAndCodeForToken } from '../store/auth'
+
 import Editor from './editor'
 import Login from './Login'
+
+import Gh from '../utils/GithubClient'
 
 const mapStateToProps = state => ({
     ghAuthToken: state.auth.ghAuthToken
 })
 
+let mapDispatchToProps = dispatch => ({
+    setAuthToken: token => dispatch(setAuthToken(token)),
+    exchangeStateAndCodeForToken: (stateToken, code) => dispatch(exchangeStateAndCodeForToken(stateToken, code)),
+    setStateToken: stateToken => dispatch(setStateToken(stateToken))
+})
+
 @connect (
-    mapStateToProps
+    mapStateToProps,
+    mapDispatchToProps
 )
 class Index extends Component {
+    constructor() {
+        super()
+        this.state = {
+            ghStateToken: null
+        }
+    }
+
+    /**
+    * 1. check for GH auth token on sessionStorage and Redux store
+    *    - if present, user is authorized
+    * 2. if no GH auth token, check for [ GH state token, code ] in `qs` & [ GH state token ] in `sessionStorage`
+    *    - if found, user is mid-auth-flow, exchange GH code for auth token
+    * 3. if no [ GH state token | code ] on `qs` or no [ GH state token ] in `sessionStorage`, user has yet to authorize
+    *    - generate Gh state token, hold it in state & save it in sessionStorage
+    */
+    handleAuthState() {
+        // if ghAuthToken is on sessionStorage and not Redux, this must be first load
+        let storedToken = window.sessionStorage.getItem('GH_AUTH_TOKEN') // TODO: use session storage instead
+        if (storedToken || this.props.ghAuthToken !== null) {
+            // if token is stored in session but not on redux store, set it on redux store
+            if (storedToken && this.props.ghAuthToken === null) {
+                this.props.setAuthToken(window.sessionStorage.getItem('GH_AUTH_TOKEN'))
+            }
+            // if ghAuthToken is on store but not on sessionStorage, we gotta store it on sessionStorage
+            else if (!storedToken && this.props.ghAuthToken !== null) {
+                this.storeTokenLocally('GH_AUTH_TOKEN', this.props.ghAuthToken)
+            }
+
+            // Check user permissions on target repo here
+
+            return
+        }
+
+        // if no ghAuthToken found anywhere, check for gh state token & code
+        let { code, stateToken } = this.getCodeAndStateFromQs(window.location.search)
+        let storedStateToken = window.sessionStorage.getItem('GH_STATE_TOKEN')
+        // if we have code & state tokens match in qs & sessionStorage
+        // use them to fetch ghAuthToken
+        if (code && stateToken && storedStateToken && stateToken === storedStateToken) {
+            this.props.exchangeStateAndCodeForToken(stateToken, code)
+        } else {
+            const ghStateToken = Gh.generateState()
+            sessionStorage.setItem('GH_STATE_TOKEN', ghStateToken)
+            this.setState({ ghStateToken })
+        }
+    }
+
+    storeTokenLocally(key, token) {
+        if (token) {
+            localStorage.setItem(key, token)
+        }
+    }
+
+    getCodeAndStateFromQs(qs) {
+        qs = qs.slice(1)
+        if (!qs) return false
+        let params = qs.split('&')
+
+        let code = params.find(param => param.startsWith('code='))
+        code = code && decodeURI(code.split('=')[1])
+
+        let stateToken = params.find(param => param.startsWith('state='))
+        stateToken = stateToken && decodeURI(stateToken.split('=')[1])
+
+        return { code, stateToken }
+    }
+
+    componentDidMount() {
+        this.handleAuthState()
+    }
+
+    componentDidUpdate() {
+        this.handleAuthState()
+    }
+
     render() {
         return (
             this.props.ghAuthToken

--- a/client/src/app/components/index.js
+++ b/client/src/app/components/index.js
@@ -25,7 +25,7 @@ let mapDispatchToProps = dispatch => ({
     exchangeCodeForToken: (stateToken, code) => dispatch(exchangeCodeForToken(stateToken, code)),
     setStateToken: stateToken => dispatch(setStateToken(stateToken)),
     setAuthorize: bool => dispatch(setAuthorize(bool)),
-    fetchUserPermission: (owner, repo) => dispatch(fetchUserPermission(owner, repo))
+    fetchUserPermission: (token, owner, repo) => dispatch(fetchUserPermission(token, owner, repo))
 })
 
 @connect (
@@ -88,7 +88,7 @@ class Index extends Component {
             this.storeTokenLocally('GH_AUTH_TOKEN', payload)
             let target = window.sessionStorage.getItem('target_repo') // grab repo url that was stored at start of login
             console.log(`found target repo in storage: ${target}`)
-            let [ owner, repo ] = target.replace(/http(?:s):\/\/github.com\//, '').split('/')
+            let [ owner, repo ] = target.replace(/https*:\/\/github.com\//, '').split('/')
             console.log(`extracted owner and repo from target: ${owner}, ${repo}`)
             this.props.fetchUserPermission(this.props.ghAuthToken, owner, repo)
         } else if (verdict === 'pending') {

--- a/client/src/app/components/index.js
+++ b/client/src/app/components/index.js
@@ -150,7 +150,7 @@ class Index extends Component {
 
     render() {
         return (
-            this.props.authenticateFetching
+            this.props.authenticateFetching || this.props.authorizeFetching
             ? <LoadScreen />
             : this.props.authorized === 'authorized'
                 ? <Editor/>

--- a/client/src/app/components/index.js
+++ b/client/src/app/components/index.js
@@ -13,7 +13,6 @@ import LoadScreen from './LoadScreen'
 import Login from './Login'
 
 import Gh from '../utils/GithubClient'
-import { getRepoFromBrowserStorage } from '../utils/browserStorage'
 
 const mapStateToProps = state => ({
     authenticateError: state.authenticate.error,
@@ -21,7 +20,7 @@ const mapStateToProps = state => ({
     authenticated: state.authenticate.authenticated,
     authorizeError: state.authorize.error,
     authorizeFetching: state.authorize.isFetching,
-    authorized: state.authenticate.authorized,
+    authorized: state.authorize.authorized,
     ghAuthToken: state.authenticate.ghAuthToken,
     targetRepo: state.authorize.targetRepo
 })
@@ -47,22 +46,21 @@ class Index extends Component {
     }
 
     checkAuthState() {
-        let access_token = window.sessionStorage.getItem('GH_AUTH_TOKEN')
-        let { owner, repo } = getRepoFromBrowserStorage()
+        let access_token = window.sessionStorage.getItem('GH_ACCESS_TOKEN')
+        let target_repo = window.sessionStorage.getItem('target_repo')
 
         // first case can only occur on cmpntDidUpdate()
         // if auth token found in store.state and stored on browser, 'authenticated'
         if (this.props.authenticated === true && access_token) {
             return { verdict: 'authenticated' }
-        } else if (access_token && owner && repo) {
+        } else if (access_token && target_repo) {
             // this case should only occur on returning to page within same browser sesh
             // user has token already, and repo should only be stored if user has permission on it
             return {
                 verdict: 'previously_authorized',
                 payload: [ // return iterable payload so I can spread it as function args
                     access_token,
-                    owner,
-                    repo // re-check permissions below
+                    target_repo // re-check permissions below
                 ]
             }
         } else if (access_token) {
@@ -101,7 +99,7 @@ class Index extends Component {
         else if (verdict === 'previously_authorized') {
             // previously authorized, try to authorize again
             this.props.setAuthToken(payload[0])
-            this.fetchUserPermission(...payload)
+            this.props.fetchUserPermission(...payload)
         } else if (verdict === 'previously_authenticated') {
             // previously auathenticated, no need to authorize again
             // we need to collect a new repo from user

--- a/client/src/app/store/auth.js
+++ b/client/src/app/store/auth.js
@@ -1,13 +1,12 @@
 import { createAction, handleActions } from "redux-actions"
 
 export const SET_AUTH_TOKEN = 'SET_AUTH_TOKEN'
-export const SET_STATE_TOKEN = 'SET_STATE_TOKEN'
 export const SET_GH_CODE = 'SET_GH_CODE'
 export const LOGOUT = 'LOGOUT'
 
 const getAuthToken = createAction('GET_AUTH_TOKEN')
 export const setAuthToken = createAction('SET_AUTH_TOKEN')
-export const setStateToken = createAction(SET_STATE_TOKEN)
+export const setStateToken = createAction('SET_STATE_TOKEN')
 export const setGHCode = createAction(SET_GH_CODE)
 export const logout = createAction(LOGOUT)
 
@@ -59,6 +58,7 @@ const initialState = {
     isFetching: false,
     error: null,
     ghAuthToken: null,
+    authorized: false,
     ghStateToken: null,
     ghCode: null
 }
@@ -85,7 +85,7 @@ const reducer = handleActions({
             error: null
         }
     )},
-    SET_STATE_TOKEN: (state, action) => {
+    [ setStateToken ]: (state, action) => {
         return {
             ...state,
             ghStateToken: action.payload

--- a/client/src/app/store/auth.js
+++ b/client/src/app/store/auth.js
@@ -42,9 +42,9 @@ export function exchangeStateAndCodeForToken(stateToken, code) {
         }).then(body => {
             if (body.access_token) {
                 dispatch(setAuthToken(body.access_token))
-                // TODO: it would be useful if this localStorage operation did not happen here in the action creator
-                window.localStorage.setItem('GH_AUTH_TOKEN', body.access_token)
-                window.localStorage.removeItem('GH_STATE_TOKEN')
+                // TODO: it would be useful if this sessionStorage operation did not happen here in the action creator
+                window.sessionStorage.setItem('GH_AUTH_TOKEN', body.access_token)
+                window.sessionStorage.removeItem('GH_STATE_TOKEN')
             } else {
                 throw new Error('No access token on response')
             }

--- a/client/src/app/store/auth.js
+++ b/client/src/app/store/auth.js
@@ -76,9 +76,11 @@ export const fetchUserPermission = (token, owner, repo) => async function(dispat
 
     try {
         let { login } = await gh.get('user')
+        console.log(`try fetching permissions using owner, repo & login, ${owner}, ${repo} & ${login}`)
         let { permission } = await gh.get('permission', { owner, repo, user: login })
         
         if (permissible.includes(permission)) {
+            console.log(`permission level "${permission}" is permissible: ${permissible.includes(permission)}`)
             dispatch(setAuthorize('authorized'))
         } else dispatch(setAuthorize('unauthorized'))
     } catch (er) {

--- a/client/src/app/store/auth.js
+++ b/client/src/app/store/auth.js
@@ -10,7 +10,7 @@ export const setStateToken = createAction('SET_STATE_TOKEN')
 export const setGHCode = createAction(SET_GH_CODE)
 export const logout = createAction(LOGOUT)
 
-export function exchangeStateAndCodeForToken(stateToken, code) {
+export function exchangeCodeForToken(code) {
     // fetch ghAuthToken from endpoint appropriate to environment
     return function(dispatch) {
         const TOKEN_SERVER = process.env.NODE_ENV === 'development'
@@ -23,7 +23,7 @@ export function exchangeStateAndCodeForToken(stateToken, code) {
             mode: 'cors',
             method: 'POST',
             headers: { 'content-type': 'application/x-www-form-urlencoded' },
-            body: `code=${code}&state=${stateToken}`
+            body: `code=${code}`
         }).then(res => {
             if (!res.ok) {
                 let bodyMethod = res.headers.get('content-type').includes('application/json')

--- a/client/src/app/store/auth.js
+++ b/client/src/app/store/auth.js
@@ -1,15 +1,32 @@
 import { createAction, handleActions } from "redux-actions"
+import Gh from '../utils/GithubClient'
 
 export const SET_AUTH_TOKEN = 'SET_AUTH_TOKEN'
 export const SET_GH_CODE = 'SET_GH_CODE'
 export const LOGOUT = 'LOGOUT'
 
 const getAuthToken = createAction('GET_AUTH_TOKEN')
+const getPermission = createAction('GET_PERMISSION')
 export const setAuthToken = createAction('SET_AUTH_TOKEN')
+const setAuthorize = createAction('SET_AUTHORIZE')
 export const setStateToken = createAction('SET_STATE_TOKEN')
 export const setGHCode = createAction(SET_GH_CODE)
 export const logout = createAction(LOGOUT)
 
+const initialState = {
+    isFetching: false,
+    error: null,
+    authenticated: false,
+    authorized: '',
+    ghAuthToken: null,
+    ghStateToken: null,
+    ghCode: null
+}
+
+/**
+ * This action creator takes the code returned from github.com/authorize
+ * and exchanges it for a GitHub auth token
+ */
 export function exchangeCodeForToken(code) {
     // fetch ghAuthToken from endpoint appropriate to environment
     return function(dispatch) {
@@ -41,9 +58,6 @@ export function exchangeCodeForToken(code) {
         }).then(body => {
             if (body.access_token) {
                 dispatch(setAuthToken(body.access_token))
-                // TODO: it would be useful if this sessionStorage operation did not happen here in the action creator
-                window.sessionStorage.setItem('GH_AUTH_TOKEN', body.access_token)
-                window.sessionStorage.removeItem('GH_STATE_TOKEN')
             } else {
                 throw new Error('No access token on response')
             }
@@ -54,37 +68,68 @@ export function exchangeCodeForToken(code) {
     }
 }
 
-const initialState = {
-    isFetching: false,
-    error: null,
-    ghAuthToken: null,
-    authorized: false,
-    ghStateToken: null,
-    ghCode: null
+export const fetchUserPermission = (token, owner, repo) => async function(dispatch) {
+    dispatch(getPermission())
+
+    let permissible = [ 'write', 'maintain', 'admin' ]
+    let gh = new Gh(token)
+
+    try {
+        let { login } = await gh.get('user')
+        let { permission } = await gh.get('permission', { owner, repo, user: login })
+        
+        if (permissible.includes(permission)) {
+            dispatch(setAuthorize('authorized'))
+        } else dispatch(setAuthorize('unauthorized'))
+    } catch (er) {
+        console.error(er)
+        dispatch(setAuthorize(er))
+    }
+
 }
 
 const reducer = handleActions({
-    [ getAuthToken ]: (state) => {
+    [ getAuthToken ]: state => {
         return ({
         ...state,
         isFetching: true,
     })},
+    [ getPermission ]: state => ({
+        ...state,
+        isFetching: true
+    }),
     [ setAuthToken ]: (state, action) => {
         return (
         action.error
         ? {
             ...state,
+            authenticated: false,
             ghAuthToken: null,
             isFetching: false,
             error: action.payload.message
         }
         : {
             ...state,
+            authenticated: true,
             ghAuthToken: action.payload,
             isFetching: false,
             error: null
         }
     )},
+    [ setAuthorize ]: (state, action) => (
+        action.error
+        ? {
+            ...state,
+            authorized: '',
+            isFetching: false,
+            error: action.payload.message
+        }
+        : {
+            ...state,
+            authorized: action.payload,
+            error: null
+        }
+    ),
     [ setStateToken ]: (state, action) => {
         return {
             ...state,

--- a/client/src/app/store/authenticate.js
+++ b/client/src/app/store/authenticate.js
@@ -1,5 +1,5 @@
 import { createAction, handleActions } from "redux-actions"
-import Gh from '../utils/GithubClient'
+import Gh from '../utils/GithubClient' // TODO: use Gh client to handle authentication
 
 export const SET_AUTH_TOKEN = 'SET_AUTH_TOKEN'
 export const SET_GH_CODE = 'SET_GH_CODE'
@@ -17,7 +17,6 @@ const initialState = {
     isFetching: false,
     error: null,
     authenticated: false,
-    authorized: '',
     ghAuthToken: null,
     ghStateToken: null,
     ghCode: null
@@ -66,28 +65,6 @@ export function exchangeCodeForToken(code) {
             dispatch(setAuthToken(er))
         })
     }
-}
-
-export const fetchUserPermission = (token, owner, repo) => async function(dispatch) {
-    dispatch(getPermission())
-
-    let permissible = [ 'write', 'maintain', 'admin' ]
-    let gh = new Gh(token)
-
-    try {
-        let { login } = await gh.get('user')
-        console.log(`try fetching permissions using owner, repo & login, ${owner}, ${repo} & ${login}`)
-        let { permission } = await gh.get('permission', { owner, repo, user: login })
-        
-        if (permissible.includes(permission)) {
-            console.log(`permission level "${permission}" is permissible: ${permissible.includes(permission)}`)
-            dispatch(setAuthorize('authorized'))
-        } else dispatch(setAuthorize('unauthorized'))
-    } catch (er) {
-        console.error(er)
-        dispatch(setAuthorize(er))
-    }
-
 }
 
 const reducer = handleActions({

--- a/client/src/app/store/authenticate.js
+++ b/client/src/app/store/authenticate.js
@@ -1,13 +1,12 @@
 import { createAction, handleActions } from "redux-actions"
 import Gh from '../utils/GithubClient' // TODO: use Gh client to handle authentication
-import { fetchUserPermissionFromBrowserStorage } from './authorize'
+import { fetchUserPermission } from './authorize'
 
 export const SET_AUTH_TOKEN = 'SET_AUTH_TOKEN'
 export const SET_GH_CODE = 'SET_GH_CODE'
 export const LOGOUT = 'LOGOUT'
 
 const getAuthToken = createAction('GET_AUTH_TOKEN')
-const getPermission = createAction('GET_PERMISSION')
 export const setAuthToken = createAction('SET_AUTH_TOKEN')
 export const setStateToken = createAction('SET_STATE_TOKEN')
 export const setGHCode = createAction(SET_GH_CODE)
@@ -40,7 +39,8 @@ export function exchangeCodeForToken(code) {
             dispatch(setAuthToken(access_token))
             window.sessionStorage.setItem('GH_ACCESS_TOKEN', access_token)
 
-            dispatch(fetchUserPermissionFromBrowserStorage(access_token))
+            let target_repo = window.sessionStorage.getItem('target_repo')
+            dispatch(fetchUserPermission(access_token, target_repo))
         } catch (er) {
             console.error(er)
             dispatch(setAuthToken(er))
@@ -52,10 +52,6 @@ const reducer = handleActions({
     [ getAuthToken ]: state => ({
         ...state,
         isFetching: true,
-    }),
-    [ getPermission ]: state => ({
-        ...state,
-        isFetching: true
     }),
     [ setAuthToken ]: (state, action) => {
         return (

--- a/client/src/app/store/authenticate.js
+++ b/client/src/app/store/authenticate.js
@@ -1,5 +1,6 @@
 import { createAction, handleActions } from "redux-actions"
 import Gh from '../utils/GithubClient' // TODO: use Gh client to handle authentication
+import { fetchUserPermissionFromBrowserStorage } from './authorize'
 
 export const SET_AUTH_TOKEN = 'SET_AUTH_TOKEN'
 export const SET_GH_CODE = 'SET_GH_CODE'
@@ -8,7 +9,6 @@ export const LOGOUT = 'LOGOUT'
 const getAuthToken = createAction('GET_AUTH_TOKEN')
 const getPermission = createAction('GET_PERMISSION')
 export const setAuthToken = createAction('SET_AUTH_TOKEN')
-const setAuthorize = createAction('SET_AUTHORIZE')
 export const setStateToken = createAction('SET_STATE_TOKEN')
 export const setGHCode = createAction(SET_GH_CODE)
 export const logout = createAction(LOGOUT)
@@ -28,51 +28,31 @@ const initialState = {
  */
 export function exchangeCodeForToken(code) {
     // fetch ghAuthToken from endpoint appropriate to environment
-    return function(dispatch) {
-        const TOKEN_SERVER = process.env.NODE_ENV === 'development'
-        ? 'http://localhost:5000'
-        : 'https://us-central1-github-commit-schema.cloudfunctions.net'
-
+    return async function(dispatch) {
         dispatch(getAuthToken())
 
-        fetch(`${TOKEN_SERVER}/token`, {
-            mode: 'cors',
-            method: 'POST',
-            headers: { 'content-type': 'application/x-www-form-urlencoded' },
-            body: `code=${code}`
-        }).then(res => {
-            if (!res.ok) {
-                let bodyMethod = res.headers.get('content-type').includes('application/json')
-                ? 'json'
-                : 'text'
-                // TODO: get at response body here, and add it to Error on a prop that will not be dropped by createAction
-                return res[bodyMethod]().then(body => {
-                    let errorMsg = body.message || `${res.status} ${res.statusText}`
-                    throw new Error(errorMsg)
-                }).catch(er => {
-                    throw er
-                })
-            }
-            return res.json()
-        }).then(body => {
-            if (body.access_token) {
-                dispatch(setAuthToken(body.access_token))
-            } else {
-                throw new Error('No access token on response')
-            }
-        }).catch(er => {
+        let gh = new Gh()
+        try {
+            let { access_token } = await gh.get('token', { code })
+
+            if (!access_token) throw new Error('No access token on response')
+
+            dispatch(setAuthToken(access_token))
+            window.sessionStorage.setItem('GH_ACCESS_TOKEN', access_token)
+
+            dispatch(fetchUserPermissionFromBrowserStorage(access_token))
+        } catch (er) {
             console.error(er)
             dispatch(setAuthToken(er))
-        })
+        }
     }
 }
 
 const reducer = handleActions({
-    [ getAuthToken ]: state => {
-        return ({
+    [ getAuthToken ]: state => ({
         ...state,
         isFetching: true,
-    })},
+    }),
     [ getPermission ]: state => ({
         ...state,
         isFetching: true
@@ -95,20 +75,6 @@ const reducer = handleActions({
             error: null
         }
     )},
-    [ setAuthorize ]: (state, action) => (
-        action.error
-        ? {
-            ...state,
-            authorized: '',
-            isFetching: false,
-            error: action.payload.message
-        }
-        : {
-            ...state,
-            authorized: action.payload,
-            error: null
-        }
-    ),
     [ setStateToken ]: (state, action) => {
         return {
             ...state,

--- a/client/src/app/store/authorize.js
+++ b/client/src/app/store/authorize.js
@@ -3,11 +3,19 @@ import Gh from '../utils/GithubClient'
 
 const getPermission = createAction('GET_PERMISSION')
 const setAuthorize = createAction('SET_AUTHORIZE')
+const setRepo = createAction('SET_REPO')
+const unsetRepo = createAction('UNSET_REPO')
 
 const initialState = {
     isFetching: false,
     error: null,
     authorized: '',
+    repo: null
+}
+
+export const unsetAndUnstoreRepo = () => {
+    window.sessionStorage.removeItem('target_repo')
+    return unsetRepo()
 }
 
 export const fetchUserPermission = (token, url) => async function(dispatch) {
@@ -25,6 +33,7 @@ export const fetchUserPermission = (token, url) => async function(dispatch) {
         let { permission } = await gh.get('permission', { owner, repo, user: login })
 
         if (permissible.includes(permission)) {
+            dispatch(setRepo(url))
             dispatch(setAuthorize('authorized'))
         } else {
             dispatch(setAuthorize('unauthorized'))
@@ -64,7 +73,16 @@ const reducer = handleActions({
             isFetching: false,
             error: null
         }
-    )
+    ),
+    [ setRepo ]: (state, action) => ({
+        ...state,
+        repo: action.payload
+    }),
+    [ unsetRepo ]: state => ({
+        ...state,
+        repo: null,
+        authorized: ''
+    })
 }, initialState)
 
 export default reducer

--- a/client/src/app/store/authorize.js
+++ b/client/src/app/store/authorize.js
@@ -18,16 +18,18 @@ export const fetchUserPermission = (token, owner, repo) => async function(dispat
 
     try {
         let { login } = await gh.get('user')
-        console.log(`try fetching permissions using owner, repo & login, ${owner}, ${repo} & ${login}`)
         let { permission } = await gh.get('permission', { owner, repo, user: login })
         
         if (permissible.includes(permission)) {
-            console.log(`permission level "${permission}" is permissible: ${permissible.includes(permission)}`)
             dispatch(setAuthorize('authorized'))
         } else dispatch(setAuthorize('unauthorized'))
     } catch (er) {
-        console.error(er)
-        dispatch(setAuthorize(er))
+        if (er.code === 403) {
+            dispatch(setAuthorize('unauthorized'))
+        } else {
+            console.error(er)
+            dispatch(setAuthorize(er))
+        }
     }
 }
 

--- a/client/src/app/store/authorize.js
+++ b/client/src/app/store/authorize.js
@@ -1,0 +1,55 @@
+import { createAction, handleActions } from "redux-actions"
+import Gh from '../utils/GithubClient'
+
+const getPermission = createAction('GET_PERMISSION')
+const setAuthorize = createAction('SET_AUTHORIZE')
+
+const initialState = {
+    isFetching: false,
+    error: null,
+    authorized: '',
+}
+
+export const fetchUserPermission = (token, owner, repo) => async function(dispatch) {
+    dispatch(getPermission())
+
+    let permissible = [ 'write', 'maintain', 'admin' ]
+    let gh = new Gh(token)
+
+    try {
+        let { login } = await gh.get('user')
+        console.log(`try fetching permissions using owner, repo & login, ${owner}, ${repo} & ${login}`)
+        let { permission } = await gh.get('permission', { owner, repo, user: login })
+        
+        if (permissible.includes(permission)) {
+            console.log(`permission level "${permission}" is permissible: ${permissible.includes(permission)}`)
+            dispatch(setAuthorize('authorized'))
+        } else dispatch(setAuthorize('unauthorized'))
+    } catch (er) {
+        console.error(er)
+        dispatch(setAuthorize(er))
+    }
+}
+
+const reducer = handleActions({
+    [ getPermission ]: state => ({
+        ...state,
+        isFetching: true
+    }),
+    [ setAuthorize ]: (state, action) => (
+        action.error
+        ? {
+            ...state,
+            authorized: '',
+            isFetching: false,
+            error: action.payload.message // NOTE: The payload here is an Error instance
+        }
+        : {
+            ...state,
+            authorized: action.payload,
+            error: null
+        }
+    )
+}, initialState)
+
+export default reducer

--- a/client/src/app/store/index.js
+++ b/client/src/app/store/index.js
@@ -3,15 +3,18 @@ import { reducer as formReducer } from "redux-form"
 import thunk from 'redux-thunk'
 import notifications from "./notifications"
 import infobox from "./infobox"
-import auth from './auth'
+import authenticate from './authenticate'
+import authorize from './authorize'
 
 const rootReducer = combineReducers({
   form: formReducer,
   notifications: notifications,
   infobox: infobox,
-  auth
+  authenticate,
+  authorize
 })
 
+// TODO: only add DEVTOOLS_EXTENSION in development
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
 const store = createStore(

--- a/client/src/app/utils/GithubClient.js
+++ b/client/src/app/utils/GithubClient.js
@@ -2,9 +2,19 @@ function GithubClient(token) {
     const TOKEN_SERVER = 'http://localhost:5000/token'
     return { get }
 
-    function get(endpoint, data) { // I think the answer here is to have this guy take a callback instead
+    async function get(endpoint, data) { // I think the answer here is to have this guy take a callback instead
         let { url, options } = getRequestParamsForEndpoint(endpoint, data)
-        let res = fetch(url, options)
+        let res = await fetch(url, options)
+        let json = await res.json()
+
+        // if bad HTTP repsonse, construct a nice error, and throw it
+        if (!res.ok) {
+            let { message } = json
+            let er = Error(message)
+            er.code = res.status
+            throw er
+        }
+
         return res
     }
 

--- a/client/src/app/utils/GithubClient.js
+++ b/client/src/app/utils/GithubClient.js
@@ -10,16 +10,27 @@ function GithubClient(token) {
 
     function getRequestParamsForEndpoint(endpoint, params) {
         switch (endpoint) {
+            case 'permission':
+                return {
+                    url: `https://api.github.com/repos/${params.owner}/${params.repo}/collaborators/${params.user}/permission`,
+                    options: {
+                        mode: 'cors',
+                        method: 'GET',
+                        headers: {
+                            Authorization: `token ${token}`
+                        }
+                    }
+                }
             case 'token':
                 return {
                     url: TOKEN_SERVER,
                     options: {
-                        mode: 'no-cors',
+                        mode: 'cors',
                         method: 'POST',
                         headers: {
                             'content-type': 'application/x-www-form-urlencoded'
                         },
-                        body: `code=${params.code}&state=${params.stateToken}`
+                        body: `code=${params.code}`
                     }
                 }
             case 'user':

--- a/client/src/app/utils/GithubClient.js
+++ b/client/src/app/utils/GithubClient.js
@@ -15,12 +15,13 @@ function GithubClient(token) {
             throw er
         }
 
-        return res
+        return json
     }
 
     function getRequestParamsForEndpoint(endpoint, params) {
         switch (endpoint) {
             case 'permission':
+                console.log(`GH.get('permission') received params ${JSON.stringify(params)}`)
                 return {
                     url: `https://api.github.com/repos/${params.owner}/${params.repo}/collaborators/${params.user}/permission`,
                     options: {

--- a/client/src/app/utils/GithubClient.js
+++ b/client/src/app/utils/GithubClient.js
@@ -1,6 +1,7 @@
 function GithubClient(token) {
     const TOKEN_SERVER = 'http://localhost:5000/token'
-    return { get }
+    let access_token = token
+    return { get, setToken }
 
     async function get(endpoint, data) { // I think the answer here is to have this guy take a callback instead
         let { url, options } = getRequestParamsForEndpoint(endpoint, data)
@@ -16,6 +17,10 @@ function GithubClient(token) {
         }
 
         return json
+    }
+
+    function setToken(token) {
+        access_token = token
     }
 
     function getRequestParamsForEndpoint(endpoint, params) {
@@ -48,7 +53,7 @@ function GithubClient(token) {
                     url: 'https://api.github.com/user',
                     options: {
                         headers: {
-                            Authorization: `token ${token}`
+                            Authorization: `token ${access_token}`
                         }
                     }
                 }
@@ -57,7 +62,7 @@ function GithubClient(token) {
                     url: `https://api.github.com/users/${params.login}/repos`,
                     options: {
                         headers: {
-                            Authorization: `token ${token}`
+                            Authorization: `token ${access_token}`
                         }
                     }
                 }

--- a/client/src/app/utils/GithubClient.js
+++ b/client/src/app/utils/GithubClient.js
@@ -11,7 +11,7 @@ function GithubClient(token) {
         if (!res.ok) {
             let { message } = json
             let er = Error(message)
-            er.code = res.status
+            er.code = +res.status
             throw er
         }
 
@@ -21,7 +21,6 @@ function GithubClient(token) {
     function getRequestParamsForEndpoint(endpoint, params) {
         switch (endpoint) {
             case 'permission':
-                console.log(`GH.get('permission') received params ${JSON.stringify(params)}`)
                 return {
                     url: `https://api.github.com/repos/${params.owner}/${params.repo}/collaborators/${params.user}/permission`,
                     options: {

--- a/client/src/app/utils/browserStorage.js
+++ b/client/src/app/utils/browserStorage.js
@@ -1,5 +1,0 @@
-export function getRepoFromBrowserStorage() {
-    let target = window.sessionStorage.getItem('target_repo') // grab repo url that was stored before redirect to GitHub auth page
-    let [ owner, repo ] = target.replace(/https*:\/\/github.com\//, '').split('/')
-    return { owner, repo }
-}

--- a/client/src/app/utils/browserStorage.js
+++ b/client/src/app/utils/browserStorage.js
@@ -1,0 +1,5 @@
+export function getRepoFromBrowserStorage() {
+    let target = window.sessionStorage.getItem('target_repo') // grab repo url that was stored before redirect to GitHub auth page
+    let [ owner, repo ] = target.replace(/https*:\/\/github.com\//, '').split('/')
+    return { owner, repo }
+}

--- a/client/src/asset/content.scss
+++ b/client/src/asset/content.scss
@@ -8,12 +8,16 @@ $content-head-h: 120px;
 }
 
 
-.content__head {
+.content__head,
+.content__target-repo {
   padding: 0 $content-pad-horiz;
-  height: $content-head-h;
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.content__head {
+  height: $content-head-h;
 }
 
 .content__head__title {

--- a/client/src/asset/loading.scss
+++ b/client/src/asset/loading.scss
@@ -13,10 +13,5 @@
 }
 
 @keyframes spin {
-    from {
-        rotate: 0deg;
-    }
-    to {
-        rotate: 360deg;
-    }
+    to { rotate: 360deg; }
 }

--- a/client/src/asset/loading.scss
+++ b/client/src/asset/loading.scss
@@ -1,9 +1,18 @@
-.spinner-container {
+.load-screen__container {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: center;
+    width: 100vw;
+    padding-bottom: 3rem;
+}
+
+.load-screen__spinner-container {
     --element-height: 1rem;
     height: calc(var(--element-height) * 2)
 }
 
-.loading-spinner {
+.load-screen__spinner {
     display: block;
     margin-left: auto; margin-right: auto;
     height: var(--element-height); width: .125rem;

--- a/client/src/asset/loading.scss
+++ b/client/src/asset/loading.scss
@@ -1,0 +1,22 @@
+.spinner-container {
+    --element-height: 1rem;
+    height: calc(var(--element-height) * 2)
+}
+
+.loading-spinner {
+    display: block;
+    margin-left: auto; margin-right: auto;
+    height: var(--element-height); width: .125rem;
+    background-color: #5a768a;
+    transform-origin: bottom;
+    animation: 3s linear infinite spin;
+}
+
+@keyframes spin {
+    from {
+        rotate: 0deg;
+    }
+    to {
+        rotate: 360deg;
+    }
+}

--- a/client/src/asset/style.scss
+++ b/client/src/asset/style.scss
@@ -13,6 +13,7 @@ $mq-size: 640px;
 @import "./close_button.scss";
 @import "./editor_widget.scss";
 @import "./editor_buttons.scss";
+@import "./loading.scss";
 
 // @import "./bsi.scss";
 @import "./bs_override.scss";


### PR DESCRIPTION
Resolves #6 

This PR deviates slightly from the issue it resolves.

Instead of pushing a new branch to the target repo as a way to test the user's permission, I'm using the GH API endpoint that is for querying the permissions of collaborators. We will still need to push a new branch, but only once the user submits the form to PR the publiccode.yml file.

This PR also changes the browser storage used from localStorage to sessionStorage. This means the GH access token and target repo are deleted when the window is closed.

#### Adds a field to the login form taking a URL of a GitHub repo
![Screen Shot 2020-02-22 at 9 48 58 PM](https://user-images.githubusercontent.com/20404311/75104412-94b08e00-55bd-11ea-8735-55deed8f8d61.png)

#### When user logs in, app uses the GitHub API endpoint /:owner/:repo/collaborators/:user/permission to test the user's permission (read, write, admin, etc) on the target repo.
If they don't have write permission or higher, keep them logged in and show a message letting them know they don't have sufficient permissions. Show the field again to choose a new repo
![Screen Shot 2020-02-22 at 9 49 25 PM](https://user-images.githubusercontent.com/20404311/75104457-f83abb80-55bd-11ea-83de-82242c8badc9.png)

#### If they have write or higher permission, show the form with the repo specified in the heading, and a button to go back and connect to a different repo
![Screen Shot 2020-02-22 at 9 49 46 PM](https://user-images.githubusercontent.com/20404311/75104467-130d3000-55be-11ea-91be-ab0126e1f108.png)

#### Click the "Connect to a different repo" button to go back to the repo entry field
![Screen Shot 2020-02-22 at 9 50 15 PM](https://user-images.githubusercontent.com/20404311/75104478-418b0b00-55be-11ea-840b-3476700764ec.png)
